### PR TITLE
fix(typeahead): Make AngularJS 1.6.0 compatible

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -339,9 +339,10 @@ angular.module('mm.foundation.typeahead', ['mm.foundation.position', 'mm.foundat
       },
       link:function (scope, element, attrs) {
         var tplUrl = $parse(attrs.templateUrl)(scope.$parent) || 'template/typeahead/typeahead-match.html';
-        $http.get(tplUrl, {cache: $templateCache}).success(function(tplContent){
+        $http.get(tplUrl, {cache: $templateCache}).then(function(response){
+           var tplContent = response.data;
            element.replaceWith($compile(tplContent.trim())(scope));
-        });
+        }, angular.noop);
       }
     };
   }])


### PR DESCRIPTION
AngularJS 1.6.0 introduced a number of breaking changes.  The typeahead module is affected by changes to the [$http](https://code.angularjs.org/1.6.0/docs/guide/migration#migrate1.5to1.6-ng-services-$http) and [$q](https://code.angularjs.org/1.6.0/docs/guide/migration#migrate1.5to1.6-ng-services-$q) module.  This PR updates the typeahead module to use `then()` instead of `success()` on HTTP promises returned by `$http.get` since `success()` no longer exists.  It also adds `angular.noop` as the onError handler for `$http.get` calls so that an exception isn't raised due to an unhandled rejected promise.